### PR TITLE
fix: target ES2018 for AsyncIterable support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es2018",
     "outDir": "out",
-    "lib": ["es6"],
+    "lib": ["es2018"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true


### PR DESCRIPTION
## Summary
- target ES2018 and update lib to access AsyncIterable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68973d8d83908330987bb47c155e33ff